### PR TITLE
fixed not using chipSelect in SD.begin()

### DIFF
--- a/IC_Tester_v2.5/IC_Tester_v2.5.ino
+++ b/IC_Tester_v2.5/IC_Tester_v2.5.ino
@@ -99,7 +99,7 @@ void SD_init()
   // Initialize SD Card Hardware
   pinMode(chipSelect, OUTPUT);
 
-  if (!SD.begin()) {
+  if (!SD.begin(chipSelect)) {
     Serial.println("Card failed, or not present");
     return;
   }

--- a/IC_Tester_v2.5/test_functions.ino
+++ b/IC_Tester_v2.5/test_functions.ino
@@ -108,7 +108,7 @@ void autoSearch(int pins)
 {
   // Auto Search Functions. Checks for matching 
   // IC definitions with the right pin count.
-  SD.begin();
+  SD.begin(chipSelect);
   File dataFile = SD.open(fname);
 
   String newCase;
@@ -224,7 +224,7 @@ void autoSearch(int pins)
     // Error while reading IC data
     Serial.print("error opening "); Serial.println(fname);
     dataFile.close();
-    SD.begin();
+    SD.begin(chipSelect);
     drawStatus("SD Card Error",RED);
     getTouch();
     resetFunc();
@@ -235,7 +235,7 @@ void manualSearch(String number)
 {
   // Manual Search function
   // takes given IC number and checks for match
-  SD.begin();
+  SD.begin(chipSelect);
   File dataFile = SD.open(fname);
 
   String buffer;
@@ -343,7 +343,7 @@ void manualSearch(String number)
     // Error reading in IC data from SD
     Serial.print("error opening "); Serial.println(fname);
     dataFile.close();
-    SD.begin();
+    SD.begin(chipSelect);
 
     digitalWrite(ledr,HIGH);
     digitalWrite(ledg,LOW);


### PR DESCRIPTION
If using a chipSelect other than 10, using SD card wasn't possible.